### PR TITLE
Add macOS build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,14 +51,11 @@ jobs:
           args: "--locked --release"
           strip: true
 
-      - name: Display structure
-        run: ls -R
-
       - name: Upload binary
         uses: actions/upload-artifact@v3.1.2
         with:
           name: ${{ matrix.platform.name }}
-          path: target/release/decky
+          path: target/${{ matrix.platform.target }}/release/decky
 
   release:
     needs: build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,6 +51,9 @@ jobs:
           args: "--locked --release"
           strip: true
 
+      - name: Display structure
+        run: ls -R
+
       - name: Upload binary
         uses: actions/upload-artifact@v3.1.2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,12 @@ jobs:
           cargo build --release
           version=$(target/release/decky --version | cut -d " " -f 2)
           echo "version=$version" >> $GITHUB_OUTPUT
+    
+      - name: Grab version
+        id: version
+        run: |
+          version=$(grep -iPo '(?<=^version = ")([^"]+)(?=")' Cargo.toml)
+          echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Upload binary
         uses: actions/upload-artifact@v3.1.2
@@ -64,4 +70,4 @@ jobs:
           prerelease: ${{ github.event.inputs.releaseAsPrerelease || true }}
           artifactErrorsFailBuild: true
           artifactContentType: "application/octet-stream"
-          tag: ${{ needs.build.outputs.version }}
+          tag: ${{ needs.version.outputs.version }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,18 +47,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install latest Rust nightly
-        uses: actions-rs/toolchain@v1
+      - name: Build binary
+        uses: houseabsolute/actions-rust-cross@v0
         with:
-            toolchain: nightly
-            default: true
-            override: true
-            components: rustfmt, clippy
-
-      - name: Build
-        id: build
-        run: |
-          cargo build --release
+          command: build
+          target: ${{ matrix.platform.target }}
+          args: "--locked --release"
+          strip: true
 
       - name: Upload binary
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,6 +46,7 @@ jobs:
         uses: houseabsolute/actions-rust-cross@v0
         with:
           command: build
+          toolchain: nightly
           target: ${{ matrix.platform.target }}
           args: "--locked --release"
           strip: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    name: Build ${{ matrix.platform.release_for }}
+    name: Build for ${{ matrix.platform.release_for }}
     strategy:
       matrix:
         platform:
@@ -41,6 +41,12 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v3
+
+      - name: Rust cache for ${{ matrix.platform.release_for }}
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: rust-${{ matrix.platform.target }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build binary
         uses: houseabsolute/actions-rust-cross@v0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,13 +35,12 @@ jobs:
         id: build
         run: |
           cargo build --release
-          version=$(target/release/decky --version | cut -d " " -f 2)
-          echo "version=$version" >> $GITHUB_OUTPUT
     
       - name: Grab version
         id: version
         run: |
           version=$(grep -iPo '(?<=^version = ")([^"]+)(?=")' Cargo.toml)
+          echo "Version code is $version"
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Upload binary
@@ -70,4 +69,4 @@ jobs:
           prerelease: ${{ github.event.inputs.releaseAsPrerelease || true }}
           artifactErrorsFailBuild: true
           artifactContentType: "application/octet-stream"
-          tag: ${{ needs.version.outputs.version }}
+          tag: ${{ needs.build.outputs.version }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,9 +17,33 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.platform.release_for }}
+    strategy:
+      matrix:
+        platform:
+          - release_for: Linux-x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            name: decky-linux-x86_64
+
+          - release_for: Linux-aarch64
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            name: decky-linux-aarch64
+
+          - release_for: macOS-x86_64
+            os: macOS-latest
+            target: x86_64-apple-darwin
+            name: decky-macOS-x86_64
+
+          - release_for: macOS-aarch64
+            os: macOS-latest
+            target: aarch64-apple-darwin
+            name: decky-macOS-aarch64
+
+    runs-on: ${{ matrix.platform.os }}
     outputs:
-      version: ${{ steps.build.outputs.version }}
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v3
 
@@ -35,18 +59,11 @@ jobs:
         id: build
         run: |
           cargo build --release
-    
-      - name: Grab version
-        id: version
-        run: |
-          version=$(grep -iPo '(?<=^version = ")([^"]+)(?=")' Cargo.toml)
-          echo "Version code is $version"
-          echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Upload binary
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: decky
+          name: ${{ matrix.platform.name }}
           path: target/release/decky
 
   release:
@@ -57,16 +74,24 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v3
+    
+      - name: Grab version
+        id: version
+        run: |
+          version=$(grep -iPo '(?<=^version = ")([^"]+)(?=")' Cargo.toml)
+          echo "Version code is $version"
+          echo "version=$version" >> $GITHUB_OUTPUT
 
       - uses: actions/download-artifact@v3
-        with:
-          name: decky
+      
+      - name: Display structure of downloaded files
+        run: ls -R
 
-      - uses: ncipollo/release-action@v1
-        with:
-          artifacts: "decky"
-          skipIfReleaseExists: true
-          prerelease: ${{ github.event.inputs.releaseAsPrerelease || true }}
-          artifactErrorsFailBuild: true
-          artifactContentType: "application/octet-stream"
-          tag: ${{ needs.build.outputs.version }}
+      # - uses: ncipollo/release-action@v1
+      #   with:
+      #     artifacts: "decky"
+      #     skipIfReleaseExists: true
+      #     prerelease: ${{ github.event.inputs.releaseAsPrerelease || true }}
+      #     artifactErrorsFailBuild: true
+      #     artifactContentType: "application/octet-stream"
+      #     tag: ${{ steps.version.outputs.version }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,15 +74,23 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - uses: actions/download-artifact@v3
-      
-      - name: Display structure of downloaded files
-        run: ls -R
+        with:
+          path: artifacts
 
-      # - uses: ncipollo/release-action@v1
-      #   with:
-      #     artifacts: "decky"
-      #     skipIfReleaseExists: true
-      #     prerelease: ${{ github.event.inputs.releaseAsPrerelease || true }}
-      #     artifactErrorsFailBuild: true
-      #     artifactContentType: "application/octet-stream"
-      #     tag: ${{ steps.version.outputs.version }}
+      - name: Rename artifacts name
+        run: |
+          cd artifacts
+          for i in *; do
+            mv $i/decky _$i
+            rm -rf $i
+            mv _$i $i
+          done
+
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: "artifacts/*"
+          skipIfReleaseExists: true
+          prerelease: ${{ github.event.inputs.releaseAsPrerelease || true }}
+          artifactErrorsFailBuild: true
+          artifactContentType: "application/octet-stream"
+          tag: ${{ steps.version.outputs.version }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,11 +26,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
             name: decky-linux-x86_64
 
-          - release_for: Linux-aarch64
-            os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            name: decky-linux-aarch64
-
           - release_for: macOS-x86_64
             os: macOS-latest
             target: x86_64-apple-darwin


### PR DESCRIPTION
confirmed `decky plugin build` works in macOS (with OrbStack as docker deamon)
Breaking changes: artifacts name now add target suffix

decky plugin deploy got error on macOS
rsync: Invalid argument passed to --chmod (D0755,F0755)
but I don't think the chmod is needed in this case, since only zip file has been transferred