### PR TITLE
Add fs mount for backend build step to allow for building frontend an…

### DIFF
--- a/src/cli/plugin/build.rs
+++ b/src/cli/plugin/build.rs
@@ -93,6 +93,10 @@ impl Builder {
                     self.tmp_build_root.join("bin").to_str().unwrap().into(),
                     "/backend/out".into(),
                 ),
+                (
+                    self.plugin_root.canonicalize()?.to_str().unwrap().into(),
+                    "/plugin".into(),
+                ),
             ],
             self.build_as_root.clone(),
             self.build_with_dev.clone(),


### PR DESCRIPTION
…d other parts of code

Before this, only things in the `<plugin root>/backend/` could be accessed by the custom backend build step. This opens that up to anything in `<plugin root>/` while maintaining the original mounts for backwards compatibility. I assume the original intent of restricting it to only the backend folder was to limit it's usage to backend compilation, but I don't really see the merit to that when it could also be used for other compile-time tasks like code generation and building frontend dependencies.

This enables the latest version of Fantastic (and future USDPL v0.11+ plugins) to generate it's frontend WebAssembly at compile time. For reference: [docker build script for Fantastic v0.5.0](https://git.ngni.us/NG-SD-Plugins/Fantastic/src/branch/decky/backend/build-docker.sh).

(This is not pressure, just information: lack of this functionality is blocking Fantastic v0.5.0 from being released onto the Decky store)