### PR TITLE
Add Podman support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,17 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aes"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,12 +135,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,33 +180,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -243,16 +204,6 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "winapi",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
 ]
 
 [[package]]
@@ -301,12 +252,6 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
@@ -368,6 +313,7 @@ dependencies = [
  "anyhow",
  "boolinator",
  "clap",
+ "dirs",
  "flexi_logger",
  "futures",
  "glob",
@@ -386,12 +332,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,7 +339,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
 ]
 
 [[package]]
@@ -443,16 +403,6 @@ name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
-
-[[package]]
-name = "flate2"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "flexi_logger"
@@ -669,15 +619,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,15 +733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,15 +765,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
-name = "jobserver"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +784,16 @@ name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.4.0",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1023,6 +956,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,29 +988,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets",
-]
-
-[[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest",
- "hmac",
- "password-hash",
- "sha2",
 ]
 
 [[package]]
@@ -1159,6 +1075,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1343,17 +1270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,12 +1331,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "subtle"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
-
-[[package]]
 name = "syn"
 version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,23 +1373,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "time"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79d09ac6b08c1ab3906a2f7cc2e81a0e27c7ae89c63812df75e52bef0751e07"
-dependencies = [
- "deranged",
- "serde",
- "time-core",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "tinyvec"
@@ -1882,46 +1775,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
- "aes",
  "byteorder",
- "bzip2",
- "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
- "flate2",
- "hmac",
- "pbkdf2",
- "sha1",
- "time",
- "zstd",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.8+zstd.1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,6 @@ sha2 = "0.10.7"
 tokio = { version = "1.24.2", features = ["full"] }
 users = "0.11.0"
 walkdir = "2.3.2"
-zip = { version = "0.6.3", deafult-features = false }
+zip = { version = "0.6.3", default-features = false }
 which = "4.4.0"
+dirs = "5"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,6 +11,22 @@ pub struct CLI {
     pub command: Command,
 }
 
+#[derive(clap::ValueEnum, Clone)]
+pub enum ContainerEngine {
+    Docker,
+    Podman,
+}
+
+impl ContainerEngine {
+    pub fn bin_name(&self) -> &str {
+        match self {
+            Self::Docker => "docker",
+            Self::Podman => "podman",
+        }
+    }
+}
+
+
 #[derive(Subcommand)]
 pub enum Command {
     Plugin(PluginCLI),
@@ -51,6 +67,9 @@ pub enum PluginCommand {
 
         #[arg(short = 's', long, value_enum, default_value = "plugin-name")]
         output_filename_source: FilenameSource,
+
+        #[arg(short = 'e', long = "engine", default_value = "docker")]
+        container_engine: ContainerEngine,
     },
     New,
     Deploy {
@@ -71,6 +90,9 @@ pub enum PluginCommand {
 
         #[arg(short = 's', long, value_enum, default_value = "plugin-name")]
         output_filename_source: FilenameSource,
+
+        #[arg(short = 'e', long = "engine", default_value = "docker")]
+        container_engine: ContainerEngine,
 
         #[arg(short = 'S', long, default_value = "true")]
         follow_symlinks: bool,

--- a/src/cli/plugin/build.rs
+++ b/src/cli/plugin/build.rs
@@ -6,7 +6,6 @@ use log::{error, info};
 use rand::distributions::{Alphanumeric, DistString};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::io::Read;
 use std::{
     fs,
     fs::File,

--- a/src/cli/plugin/build.rs
+++ b/src/cli/plugin/build.rs
@@ -17,8 +17,8 @@ use walkdir::WalkDir;
 use zip::{write::FileOptions, ZipWriter};
 
 use crate::{
-    cli::FilenameSource,
-    docker,
+    cli::{FilenameSource, ContainerEngine},
+    container_engine,
     plugin::{CustomBackend, Plugin},
 };
 
@@ -34,13 +34,15 @@ pub struct Builder {
     pub build_with_dev: bool,
     pub follow_symlinks: bool,
     pub output_filename_source: FilenameSource,
+    pub container_engine: ContainerEngine,
 }
 
 impl Builder {
     pub async fn build_frontend(&self) -> Result<()> {
         info!("Building frontend");
 
-        docker::run_image(
+        container_engine::run_image(
+            &self.container_engine,
             self.docker_image.clone(),
             vec![
                 (
@@ -66,7 +68,8 @@ impl Builder {
 
         match self.plugin.custom_backend {
             CustomBackend::Dockerfile => {
-                image_tag = docker::build_image(
+                image_tag = container_engine::build_image(
+                    &self.container_engine,
                     self.plugin_root.join("backend").join("Dockerfile"),
                     self.plugin.meta.name.to_ascii_lowercase().replace(" ", "-"),
                 )
@@ -76,7 +79,8 @@ impl Builder {
             CustomBackend::None => {}
         }
 
-        docker::run_image(
+        container_engine::run_image(
+            &self.container_engine,
             image_tag.into(),
             vec![
                 (
@@ -390,12 +394,13 @@ impl Builder {
         build_with_dev: bool,
         follow_symlinks: bool,
         output_filename_source: FilenameSource,
+        container_engine: ContainerEngine,
     ) -> Result<Self> {
         if !output_root.exists() {
             std::fs::create_dir(&output_root)?;
         }
 
-        docker::ensure_availability()?;
+        container_engine::ensure_availability(&container_engine)?;
 
         Builder::validate_tmp_build_root(&tmp_build_root).unwrap();
 
@@ -415,6 +420,7 @@ impl Builder {
             build_with_dev,
             follow_symlinks,
             output_filename_source,
+            container_engine,
         })
     }
 }

--- a/src/cli/plugin/deploy.rs
+++ b/src/cli/plugin/deploy.rs
@@ -1,4 +1,4 @@
-use std::env::home_dir;
+use dirs::home_dir;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 

--- a/src/cli/plugin/deploy.rs
+++ b/src/cli/plugin/deploy.rs
@@ -8,7 +8,7 @@ use rand::distributions::{Alphanumeric, DistString};
 
 use crate::cli::plugin::build::Builder;
 use crate::plugin::DeckFile;
-use crate::{cli::FilenameSource, plugin::Plugin};
+use crate::{cli::FilenameSource, cli::ContainerEngine, plugin::Plugin};
 
 #[derive(Clone)]
 pub struct Deployer {
@@ -230,6 +230,7 @@ impl Deployer {
         build_with_dev: bool,
         follow_symlinks: bool,
         output_filename_source: FilenameSource,
+        container_engine: ContainerEngine,
         deck_ip: Option<String>,
         deck_port: Option<String>,
         deck_pass: Option<String>,
@@ -246,6 +247,7 @@ impl Deployer {
             build_with_dev,
             follow_symlinks,
             output_filename_source,
+            container_engine,
         )
         .expect("Could not create builder");
 

--- a/src/cli/plugin/mod.rs
+++ b/src/cli/plugin/mod.rs
@@ -14,6 +14,7 @@ pub async fn parse(args: &PluginCLI) -> Result<()> {
             build_with_dev,
             follow_symlinks,
             output_filename_source,
+            container_engine
         } => {
             build::Builder::new(
                 plugin_path.into(),
@@ -23,6 +24,7 @@ pub async fn parse(args: &PluginCLI) -> Result<()> {
                 build_with_dev.clone(),
                 follow_symlinks.clone(),
                 output_filename_source.clone(),
+                container_engine.clone(),
             )?
             .run()
             .await
@@ -36,6 +38,7 @@ pub async fn parse(args: &PluginCLI) -> Result<()> {
             build_with_dev,
             follow_symlinks,
             output_filename_source,
+            container_engine,
             deck_ip,
             deck_port,
             deck_pass,
@@ -50,6 +53,7 @@ pub async fn parse(args: &PluginCLI) -> Result<()> {
                 build_with_dev.clone(),
                 follow_symlinks.clone(),
                 output_filename_source.clone(),
+                container_engine.clone(),
                 deck_ip.clone(),
                 deck_port.clone(),
                 deck_pass.clone(),

--- a/src/container_engine.rs
+++ b/src/container_engine.rs
@@ -38,27 +38,27 @@ async fn run_command(cmd: &mut Command) -> Result<()> {
     )
 }
 
-pub fn ensure_availability() -> Result<()> {
-    let exit_status = which("docker")
+pub fn ensure_availability(engine: &crate::cli::ContainerEngine) -> Result<()> {
+    let exit_status = which(engine.bin_name())
         .map(|_| Ok(()))
-        .context("`docker` program not found. Make sure it is installed and in your $PATH. For more information visit https://docs.docker.com/desktop/troubleshoot/overview/")
+        .context(format!("`{}` program not found. Make sure it is installed and in your $PATH. For more information visit https://docs.docker.com/desktop/troubleshoot/overview/", engine.bin_name()))
         .and_then(|_| {
-                std::process::Command::new("docker")
+                std::process::Command::new(engine.bin_name())
                     .arg("ps")
                     .status()
-                    .context("Error while checking for Docker availability. Please run `docker ps` in your terminal and fix any errors that show up.")
+                    .context(format!("Error while checking for {0} availability. Please run `{0} ps` in your terminal and fix any errors that show up.", engine.bin_name()))
             }
         )?;
     if !exit_status.success() {
-        Err(anyhow!("exit status {}: Docker is installed but doesn't seem to be available! Is the daemon running? For more information visit https://docs.docker.com/desktop/troubleshoot/overview/", exit_status.code().unwrap()))
+        Err(anyhow!("exit status {}: {1} is installed but doesn't seem to be available! Is the daemon running? For more information visit https://docs.{1}.com/desktop/troubleshoot/overview/", exit_status.code().unwrap(), engine.bin_name()))
     } else {
         Ok(())
     }
 }
 
 // docker build -f $PWD/backend/Dockerfile -t "$docker_name" .
-pub async fn build_image(dockerfile: PathBuf, tag: String) -> Result<String> {
-    let mut cmd = Command::new("docker");
+pub async fn build_image(engine: &crate::cli::ContainerEngine, dockerfile: PathBuf, tag: String) -> Result<String> {
+    let mut cmd = Command::new(engine.bin_name());
     let full_command = cmd
         .arg("build")
         .arg("-f")
@@ -74,12 +74,13 @@ pub async fn build_image(dockerfile: PathBuf, tag: String) -> Result<String> {
 
 // docker run --rm -i -v $PWD/backend:/backend -v /tmp/output/$plugin/backend/out:/backend/out --entrypoint /backend/entrypoint.sh "$docker_name"
 pub async fn run_image(
+    engine: &crate::cli::ContainerEngine,
     tag: String,
     binds: Vec<(String, String)>,
     run_as_root: bool,
     run_with_dev: bool,
 ) -> Result<()> {
-    let mut cmd = Command::new("docker");
+    let mut cmd = Command::new(engine.bin_name());
     let mut command_with_default_args = cmd.arg("run").arg("--rm");
 
     if !run_as_root {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
-#![feature(exit_status_error)]
+//#![feature(exit_status_error)]
 mod cli;
-mod docker;
+mod container_engine;
 mod plugin;
 
 use anyhow::Result;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -14,6 +14,7 @@ pub enum CustomBackend {
 pub struct Plugin {
     pub meta: PluginFile,
     pub deck: DeckFile,
+    #[allow(dead_code)]
     pub root: PathBuf,
     pub custom_backend: CustomBackend,
 }


### PR DESCRIPTION
This adds a new cli arg to specify the container engine (defaults to docker) and changes internals to account for that. This also fixes an issue with running the containers as a non-root user due to SELinux preventing writing to writeable folders.

I've tested this with root Docker and non-root Podman to build PowerTools and haven't encountered any issues except the one I already [opened a PR](https://github.com/SteamDeckHomebrew/holo-docker/pull/10) for. Please merge that before this PR to avoid Rust plugins builds breaking.