### PR TITLE
feat: add support for custom compression options

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,7 +40,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Rust cache for ${{ matrix.platform.release_for }}
         uses: Swatinem/rust-cache@v2
@@ -58,7 +58,7 @@ jobs:
           strip: true
 
       - name: Upload binary
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.platform.name }}
           path: target/${{ matrix.platform.target }}/release/decky
@@ -70,7 +70,7 @@ jobs:
       contents: write
     if: github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
     
       - name: Grab version
         id: version
@@ -79,7 +79,7 @@ jobs:
           echo "Version code is $version"
           echo "version=$version" >> $GITHUB_OUTPUT
 
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v4
         with:
           path: artifacts
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,7 +129,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
  "object",
  "rustc-demangle",
 ]
@@ -398,6 +404,16 @@ name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
+name = "flate2"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.8.0",
+]
 
 [[package]]
 name = "flexi_logger"
@@ -831,6 +847,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -1846,4 +1871,5 @@ dependencies = [
  "byteorder",
  "crc32fast",
  "crossbeam-utils",
+ "flate2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "decky"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "boolinator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,17 +103,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,14 +406,12 @@ dependencies = [
 
 [[package]]
 name = "flexi_logger"
-version = "0.24.2"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade8e86c48285f138a4d6ca15a2912e39bd6c74d62db42da4f1985f651a0b057"
+checksum = "4aecae2cdf1c33e1c83896a37cc155e207a6358c915795932c338126e8eb3392"
 dependencies = [
- "atty",
  "chrono",
  "glob",
- "lazy_static",
  "log",
  "nu-ansi-term",
  "regex",
@@ -616,15 +603,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -755,7 +733,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -889,12 +867,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -912,7 +889,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -980,12 +957,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
- "users",
+ "uzers",
  "walkdir",
  "which",
  "zip",
@@ -1534,20 +1534,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
-]
-
-[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uzers"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df81ff504e7d82ad53e95ed1ad5b72103c11253f39238bcc0235b90768a97dd"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,6 @@ sha2 = "0.10.7"
 tokio = { version = "1.24.2", features = ["full"] }
 users = "0.11.0"
 walkdir = "2.3.2"
-zip = { version = "0.6.3", default-features = false }
+zip = { version = "0.6.3", default-features = false, features = ["deflate"] }
 which = "4.4.0"
 dirs = "5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 sha2 = "0.10.7"
 tokio = { version = "1.24.2", features = ["full"] }
-users = "0.11.0"
+uzers = "0.12.1"
 walkdir = "2.3.2"
 zip = { version = "0.6.3", default-features = false, features = ["deflate"] }
 which = "4.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decky"
-version = "0.0.3"
+version = "0.0.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1.0.68"
 boolinator = "2.4.0"
 clap = { version = "4.1.4", features = ["derive"] }
-flexi_logger = "0.24"
+flexi_logger = "0.29"
 futures = "0.3.25"
 glob = "0.3.1"
 itertools = "0.10.5"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -27,6 +27,12 @@ impl ContainerEngine {
 }
 
 
+#[derive(clap::ValueEnum, Clone)]
+pub enum CompressMethod {
+    Deflate,
+    Store,
+}
+
 #[derive(Subcommand)]
 pub enum Command {
     Plugin(PluginCLI),
@@ -70,6 +76,12 @@ pub enum PluginCommand {
 
         #[arg(short = 'e', long = "engine", default_value = "docker")]
         container_engine: ContainerEngine,
+
+        #[arg(short = 'm', long, default_value = "deflate")]
+        compression_method: CompressMethod,
+
+        #[arg(short = 'l', long)]
+        compression_level: Option<i32>,
     },
     New,
     Deploy {
@@ -93,6 +105,12 @@ pub enum PluginCommand {
 
         #[arg(short = 'e', long = "engine", default_value = "docker")]
         container_engine: ContainerEngine,
+
+        #[arg(short = 'm', long, default_value = "deflate")]
+        compression_method: CompressMethod,
+
+        #[arg(short = 'l', long)]
+        compression_level: Option<i32>,
 
         #[arg(short = 'S', long, default_value = "true")]
         follow_symlinks: bool,

--- a/src/cli/plugin/deploy.rs
+++ b/src/cli/plugin/deploy.rs
@@ -7,6 +7,7 @@ use log::info;
 use rand::distributions::{Alphanumeric, DistString};
 
 use crate::cli::plugin::build::Builder;
+use crate::cli::CompressMethod;
 use crate::plugin::DeckFile;
 use crate::{cli::FilenameSource, cli::ContainerEngine, plugin::Plugin};
 
@@ -231,6 +232,8 @@ impl Deployer {
         follow_symlinks: bool,
         output_filename_source: FilenameSource,
         container_engine: ContainerEngine,
+        compression_method: CompressMethod,
+        compression_level: Option<i32>,
         deck_ip: Option<String>,
         deck_port: Option<String>,
         deck_pass: Option<String>,
@@ -248,6 +251,8 @@ impl Deployer {
             follow_symlinks,
             output_filename_source,
             container_engine,
+            compression_method,
+            compression_level,
         )
         .expect("Could not create builder");
 

--- a/src/cli/plugin/mod.rs
+++ b/src/cli/plugin/mod.rs
@@ -14,7 +14,9 @@ pub async fn parse(args: &PluginCLI) -> Result<()> {
             build_with_dev,
             follow_symlinks,
             output_filename_source,
-            container_engine
+            container_engine,
+            compression_method,
+            compression_level,
         } => {
             build::Builder::new(
                 plugin_path.into(),
@@ -25,6 +27,8 @@ pub async fn parse(args: &PluginCLI) -> Result<()> {
                 follow_symlinks.clone(),
                 output_filename_source.clone(),
                 container_engine.clone(),
+                compression_method.clone(),
+                compression_level.clone(),
             )?
             .run()
             .await
@@ -44,6 +48,8 @@ pub async fn parse(args: &PluginCLI) -> Result<()> {
             deck_pass,
             deck_key,
             deck_dir,
+            compression_method,
+            compression_level,
         } => {
             deploy::Deployer::new(
                 plugin_path.into(),
@@ -54,6 +60,8 @@ pub async fn parse(args: &PluginCLI) -> Result<()> {
                 follow_symlinks.clone(),
                 output_filename_source.clone(),
                 container_engine.clone(),
+                compression_method.clone(),
+                compression_level.clone(),
                 deck_ip.clone(),
                 deck_port.clone(),
                 deck_pass.clone(),

--- a/src/container_engine.rs
+++ b/src/container_engine.rs
@@ -6,7 +6,7 @@ use tokio::{
     io::{AsyncBufReadExt, BufReader},
     process::Command,
 };
-use users::{get_effective_gid, get_effective_uid};
+use uzers::{get_effective_gid, get_effective_uid};
 use which::which;
 
 async fn run_command(cmd: &mut Command) -> Result<()> {


### PR DESCRIPTION
Adds option to use `deflate` as compression algo for ZIP instead of `store` (used by default). Also, allows specifying the compression level for `deflate` compression.

CI updated to use `actions/download-artifact@4` & `actions/upload-artifact@4` to fix issue with last CI build.